### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - run: go mod download
       - run: go build -v .
       - name: Run linters
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: 2
 run:
   go: "1.23"
   timeout: 5m
@@ -21,7 +22,6 @@ linters:
     - perfsprint
     - prealloc
     - tagliatelle
-    - tenv
     - testpackage
     - varnamelen
     - wrapcheck

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,7 +10,7 @@ install: build
 
 .PHONY: install_golangci_lint
 install_golangci_lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.64.5
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v2.2.2
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
## Summary
- update golangci-lint installation target
- update golangci-lint action version
- add configuration version for golangci-lint and remove defunct linter

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687372aa4738833290fd5be3e50b1ff9